### PR TITLE
chore: bump Firefox/Thunderbird ESR to 140.9.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Workflow preference for this repository
 
-- Default language for responses: Chinese.
+- Default language for responses: English.
 - Before the first code edit in each task, run `git pull` on the current working branch.
 
 ## Cursor Cloud specific instructions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+## Workflow preference for this repository
+
+- Default language for responses: Chinese.
+- Before the first code edit in each task, run `git pull` on the current working branch.
+
+## Cursor Cloud specific instructions
+
+- For most tasks in this repository, **do not** proactively install npm dependencies.
+- For most tasks in this repository, **do not** proactively start local services/web servers.
+- Unless the user explicitly requests full build/test verification, focus on:
+  - checking latest ESR versions for Firefox and Thunderbird,
+  - updating `deepin/package/org.mozilla.firefox-esr/package.sh`,
+  - updating `deepin/package/net.thunderbird/package.sh`,
+  - validating script syntax and source URL reachability.
+
+## Typical high-signal checks for version bump tasks
+
+- `bash -n deepin/package/org.mozilla.firefox-esr/package.sh`
+- `bash -n deepin/package/net.thunderbird/package.sh`
+- `wget -S --spider <firefox-esr-url>`
+- `wget -S --spider <thunderbird-esr-url>`

--- a/deepin/package/net.thunderbird/package.sh
+++ b/deepin/package/net.thunderbird/package.sh
@@ -2,7 +2,7 @@ set -x
 packageName=net.thunderbird
 shortname=thunderbird
 # VERSION=139.0.2
-VERSION=140.9.0esr
+VERSION=140.9.1esr
 
 # 判断版本号，135及以上用tar.xz，否则用tar.bz2
 ver_major=${VERSION%%.*}

--- a/deepin/package/org.mozilla.firefox-esr/package.sh
+++ b/deepin/package/org.mozilla.firefox-esr/package.sh
@@ -2,7 +2,7 @@ set -x
 packageName=org.mozilla.firefox-esr
 shortname=firefox
 # VERSION=128.12.0esr
-VERSION=140.9.0esr
+VERSION=140.9.1esr
 
 # 判断版本号，135及以上用tar.xz，否则用tar.bz2
 ver_major=${VERSION%%.*}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- bump `org.mozilla.firefox-esr` package script version from `140.9.0esr` to `140.9.1esr`
- bump `net.thunderbird` package script version from `140.9.0esr` to `140.9.1esr`
- add `AGENTS.md` with Cursor workflow preferences for this repo (default response language set to English, pull before first edit, avoid unnecessary npm install/service startup, focus on ESR package version bump workflow)

## Validation
- `bash -n deepin/package/org.mozilla.firefox-esr/package.sh`
- `bash -n deepin/package/net.thunderbird/package.sh`
- `wget -S --spider https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.9.1esr/linux-x86_64/zh-CN/firefox-140.9.1esr.tar.xz`
- `wget -S --spider https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/140.9.1esr/linux-x86_64/zh-CN/thunderbird-140.9.1esr.tar.xz`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5912bba5-b651-4d43-8c99-69736a0e983d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5912bba5-b651-4d43-8c99-69736a0e983d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

