### PR TITLE
Bump Firefox and Thunderbird ESR to 140.10.0esr

### DIFF
--- a/_posts/2026-04-26-firefox-thunderbird-esr-140-10-0-upgrade.md
+++ b/_posts/2026-04-26-firefox-thunderbird-esr-140-10-0-upgrade.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Upgrade Record: Firefox ESR and Thunderbird ESR 140.10.0"
+date: 2026-04-26 20:45:00 +0800
+categories: packaging update
+tags: [deepin, firefox-esr, thunderbird, esr]
+---
+
+Today I completed a deepin Linux packaging upgrade for two applications:
+
+- Firefox ESR: `140.9.1esr` -> `140.10.0esr`
+- Thunderbird ESR: `140.9.1esr` -> `140.10.0esr`
+
+This is a deepin package maintenance update, not a global release for all platforms.
+
+### What I updated
+
+1. Bumped the ESR version in both deepin packaging scripts.
+2. Verified script syntax with `bash -n`.
+3. Confirmed source URL reachability for the new ESR archives.
+
+### Why this update matters
+
+Keeping Firefox ESR and Thunderbird ESR up to date for deepin Linux helps maintain security patches, reduces packaging drift, and keeps downstream users on a stable ESR track.
+
+I will continue checking Mozilla ESR releases and record future deepin package upgrades in follow-up posts.

--- a/deepin/package/net.thunderbird/package.sh
+++ b/deepin/package/net.thunderbird/package.sh
@@ -2,7 +2,7 @@ set -x
 packageName=net.thunderbird
 shortname=thunderbird
 # VERSION=139.0.2
-VERSION=140.9.1esr
+VERSION=140.10.0esr
 
 # 判断版本号，135及以上用tar.xz，否则用tar.bz2
 ver_major=${VERSION%%.*}

--- a/deepin/package/org.mozilla.firefox-esr/package.sh
+++ b/deepin/package/org.mozilla.firefox-esr/package.sh
@@ -2,7 +2,7 @@ set -x
 packageName=org.mozilla.firefox-esr
 shortname=firefox
 # VERSION=128.12.0esr
-VERSION=140.9.1esr
+VERSION=140.10.0esr
 
 # 判断版本号，135及以上用tar.xz，否则用tar.bz2
 ver_major=${VERSION%%.*}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump deepin package scripts for Firefox ESR and Thunderbird ESR from `140.9.1esr` to `140.10.0esr`.
- Add a new English post to record this upgrade for deepin Linux packaging work:
  - `_posts/2026-04-26-firefox-thunderbird-esr-140-10-0-upgrade.md`

## Validation
- `python3` front matter validation for the new post passed.
- `bash -n deepin/package/org.mozilla.firefox-esr/package.sh`
- `bash -n deepin/package/net.thunderbird/package.sh`
- `wget -S --spider https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.10.0esr/linux-x86_64/zh-CN/firefox-140.10.0esr.tar.xz`
- `wget -S --spider https://download-installer.cdn.mozilla.net/pub/thunderbird/releases/140.10.0esr/linux-x86_64/zh-CN/thunderbird-140.10.0esr.tar.xz`

## Upstream check
- Mozilla product-details reports:
  - `FIREFOX_ESR=140.10.0esr`
  - `THUNDERBIRD_ESR=140.10.0esr`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2878aee7-0d04-45c1-bafb-3586120b5230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2878aee7-0d04-45c1-bafb-3586120b5230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

